### PR TITLE
V2 to V3 in _plinode_setup_bkup.sh

### DIFF
--- a/_plinode_setup_bkup.sh
+++ b/_plinode_setup_bkup.sh
@@ -31,7 +31,7 @@ FUNC_DB_VARS(){
         echo -e "${GREEN} #### NOTICE: No backup VARIABLES file found.. ####${NC}"
         echo
         echo -e "${GREEN} ..creating local backup vars file '$HOME/$PLI_DB_VARS_FILE' ${NC}"
-        cp -n ~/pli2vn/sample_bkup.vars ~/$PLI_DB_VARS_FILE
+        cp -n ~/pli3setup/sample_bkup.vars ~/$PLI_DB_VARS_FILE
         chmod 600 ~/$PLI_DB_VARS_FILE
     fi
     source ~/$PLI_DB_VARS_FILE


### PR DESCRIPTION
Fixed an error in the copy source directory of sample_bkup.vars. Changed from "pli2vn" to "pli3setup".